### PR TITLE
docs: add test class XML summaries

### DIFF
--- a/src/BigO.Types.Tests/DateRangeCoreTests.cs
+++ b/src/BigO.Types.Tests/DateRangeCoreTests.cs
@@ -1,5 +1,8 @@
 ﻿namespace BigO.Types.Tests;
 
+/// <summary>
+///     Unit tests for core <see cref="DateRange" /> behavior.
+/// </summary>
 public sealed class DateRangeCoreTests
 {
     private const char Infinity = '\u221E';

--- a/src/BigO.Types.Tests/DateRangeExtensionsContainsTests.cs
+++ b/src/BigO.Types.Tests/DateRangeExtensionsContainsTests.cs
@@ -1,5 +1,8 @@
 ﻿namespace BigO.Types.Tests;
 
+/// <summary>
+///     Tests for the <see cref="DateRangeExtensions.Contains(DateRange, DateOnly)" /> extension method.
+/// </summary>
 public sealed class DateRangeExtensionsContainsTests
 {
     private static DateOnly D(int y, int m, int d) => new(y, m, d);

--- a/src/BigO.Types.Tests/DateRangeExtensionsDurationTests.cs
+++ b/src/BigO.Types.Tests/DateRangeExtensionsDurationTests.cs
@@ -1,5 +1,8 @@
 ﻿namespace BigO.Types.Tests;
 
+/// <summary>
+///     Tests for duration-related extension methods on <see cref="DateRange" />.
+/// </summary>
 public sealed class DateRangeExtensionsDurationTests
 {
     private static DateOnly D(int y, int m, int d) => new(y, m, d);

--- a/src/BigO.Types.Tests/DateRangeExtensionsEnumerateDaysTests.cs
+++ b/src/BigO.Types.Tests/DateRangeExtensionsEnumerateDaysTests.cs
@@ -1,5 +1,8 @@
 ﻿namespace BigO.Types.Tests;
 
+/// <summary>
+///     Tests for <see cref="DateRangeExtensions.EnumerateDays(DateRange, int?)" />.
+/// </summary>
 public sealed class DateRangeExtensionsEnumerateDaysTests
 {
     private static DateOnly D(int y, int m, int d) => new(y, m, d);

--- a/src/BigO.Types.Tests/DateRangeExtensionsGetWeeksInRangeTests.cs
+++ b/src/BigO.Types.Tests/DateRangeExtensionsGetWeeksInRangeTests.cs
@@ -1,5 +1,8 @@
 ﻿namespace BigO.Types.Tests;
 
+/// <summary>
+///     Tests for splitting <see cref="DateRange" /> values into week-sized chunks.
+/// </summary>
 public sealed class DateRangeExtensionsGetWeeksInRangeTests
 {
     private static DateOnly D(int y, int m, int d) => new(y, m, d);

--- a/src/BigO.Types.Tests/DateRangeExtensionsOverlapsIntersectionTests.cs
+++ b/src/BigO.Types.Tests/DateRangeExtensionsOverlapsIntersectionTests.cs
@@ -1,5 +1,9 @@
 ﻿namespace BigO.Types.Tests;
 
+/// <summary>
+///     Tests for <see cref="DateRangeExtensions.Overlaps(DateRange, DateRange)" />
+///     and <see cref="DateRangeExtensions.Intersection(DateRange, DateRange)" />.
+/// </summary>
 public sealed class DateRangeExtensionsOverlapsIntersectionTests
 {
     private static DateOnly D(int y, int m, int d) => new(y, m, d);

--- a/src/BigO.Types.Tests/DateRangeFormatParseTests.cs
+++ b/src/BigO.Types.Tests/DateRangeFormatParseTests.cs
@@ -2,6 +2,9 @@
 
 namespace BigO.Types.Tests;
 
+/// <summary>
+///     Tests verifying <see cref="DateRange" /> formatting and parsing.
+/// </summary>
 public sealed class DateRangeFormatParseTests
 {
     private const char Infinity = '\u221E';

--- a/src/BigO.Types.Tests/DateRangeJsonConverterTests.cs
+++ b/src/BigO.Types.Tests/DateRangeJsonConverterTests.cs
@@ -3,6 +3,9 @@ using System.Text.Json;
 
 namespace BigO.Types.Tests;
 
+/// <summary>
+///     Tests for the JSON converter that serializes <see cref="DateRange" /> values.
+/// </summary>
 public sealed class DateRangeJsonConverterTests
 {
     private const string InfinityLiteral = "\u221E";

--- a/src/BigO.Types.Tests/DateRangeRoundTripPropertyTests.cs
+++ b/src/BigO.Types.Tests/DateRangeRoundTripPropertyTests.cs
@@ -2,6 +2,10 @@
 
 namespace BigO.Types.Tests;
 
+/// <summary>
+///     Property-based tests verifying that <see cref="DateRange" /> values round-trip
+///     through string and JSON representations.
+/// </summary>
 public sealed class DateRangeRoundTripPropertyTests
 {
     private static readonly Random Rng = new(42);

--- a/src/BigO.Types.Tests/EmailAddressConstructionTests.cs
+++ b/src/BigO.Types.Tests/EmailAddressConstructionTests.cs
@@ -1,5 +1,8 @@
 ﻿namespace BigO.Types.Tests;
 
+/// <summary>
+///     Tests covering construction of <see cref="EmailAddress" /> instances from strings.
+/// </summary>
 public sealed class EmailAddressConstructionTests
 {
     [Theory]

--- a/src/BigO.Types.Tests/EmailAddressDefaultInstanceTests.cs
+++ b/src/BigO.Types.Tests/EmailAddressDefaultInstanceTests.cs
@@ -2,6 +2,9 @@
 
 namespace BigO.Types.Tests;
 
+/// <summary>
+///     Tests describing the behavior of the default <see cref="EmailAddress" /> value.
+/// </summary>
 public sealed class EmailAddressDefaultInstanceTests
 {
     [Fact]

--- a/src/BigO.Types.Tests/EmailAddressEqualityAndOrderingTests.cs
+++ b/src/BigO.Types.Tests/EmailAddressEqualityAndOrderingTests.cs
@@ -1,5 +1,8 @@
 ﻿namespace BigO.Types.Tests;
 
+/// <summary>
+///     Tests verifying equality and comparison semantics for <see cref="EmailAddress" />.
+/// </summary>
 public sealed class EmailAddressEqualityAndOrderingTests
 {
     [Theory]

--- a/src/BigO.Types.Tests/EmailAddressNormalizationTests.cs
+++ b/src/BigO.Types.Tests/EmailAddressNormalizationTests.cs
@@ -2,6 +2,9 @@
 
 namespace BigO.Types.Tests;
 
+/// <summary>
+///     Tests confirming the normalization rules applied to <see cref="EmailAddress" />.
+/// </summary>
 public sealed class EmailAddressNormalizationTests
 {
     [Fact]

--- a/src/BigO.Types.Tests/EmailAddressTryParseAndValidationTests.cs
+++ b/src/BigO.Types.Tests/EmailAddressTryParseAndValidationTests.cs
@@ -1,5 +1,9 @@
 ﻿namespace BigO.Types.Tests;
 
+/// <summary>
+///     Tests for <see cref="EmailAddress.TryParse(string?, out EmailAddress)" />
+///     and related validation helpers.
+/// </summary>
 public sealed class EmailAddressTryParseAndValidationTests
 {
     [Theory]

--- a/src/BigO.Types.Tests/EmailAddress_MailAddressAdapterTests.cs
+++ b/src/BigO.Types.Tests/EmailAddress_MailAddressAdapterTests.cs
@@ -2,6 +2,10 @@
 
 namespace BigO.Types.Tests;
 
+/// <summary>
+///     Tests for converting <see cref="EmailAddress" /> instances into
+///     <see cref="System.Net.Mail.MailAddress" /> values.
+/// </summary>
 public sealed class EmailAddressMailAddressAdapterTests
 {
     [Fact]

--- a/src/BigO.Types.Tests/EmailTestHelper.cs
+++ b/src/BigO.Types.Tests/EmailTestHelper.cs
@@ -3,6 +3,9 @@ using System.Globalization;
 
 namespace BigO.Types.Tests;
 
+/// <summary>
+///     Utility helpers used by <see cref="EmailAddress" /> unit tests.
+/// </summary>
 internal static class EmailTestHelper
 {
     /// <summary>


### PR DESCRIPTION
## Summary
- add XML `<summary>` documentation to every test class in the test project

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ed764754c832a85eabe0fe9ba1ae2